### PR TITLE
Update SigV4RequestSigner.cs to work with missing x-amz-security-toke…

### DIFF
--- a/src/SigV4RequestSigner.cs
+++ b/src/SigV4RequestSigner.cs
@@ -84,7 +84,9 @@ namespace Amazon.Neptune.Gremlin.Driver
             return new Action<ClientWebSocketOptions>(options => { 
                     options.SetRequestHeader("host", neptune_endpoint);
                     options.SetRequestHeader("x-amz-date", signedrequest.Headers.GetValues("x-amz-date").FirstOrDefault());
-                    options.SetRequestHeader("x-amz-security-token", signedrequest.Headers.GetValues("x-amz-security-token").FirstOrDefault());
+                    if (signedrequest.Headers.TryGetValues("x-amz-security-token", out var values)) {
+                        options.SetRequestHeader("x-amz-security-token", values.FirstOrDefault());
+                    }
                     options.SetRequestHeader("Authorization", signedrequest.Headers.GetValues("Authorization").FirstOrDefault());
                     }); 
         }
@@ -117,7 +119,7 @@ namespace Amazon.Neptune.Gremlin.Driver
                 request.Headers.Host = request.RequestUri.Host + ":" + request.RequestUri.Port;
             }
             
-            if (sessionToken != null ) {
+            if (!string.IsNullOrEmpty(sessionToken)) {
                 request.Headers.Add("x-amz-security-token",sessionToken);
             }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When developing locally with my IAM user keys i noticed the session token is an empty string instead of null. Updated the check and adding the ` x-amz-security-token` header only if a session token is available.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
